### PR TITLE
Fix env problem?

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,5 +35,4 @@ dependencies:
       - bs4
       - lxml
       - datetime
-      - os
       - scikit-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.0"]
-
-[tool.setuptools_scm]
-write_to = "src/bask/_version.py"
+requires = ["setuptools>=45", "wheel"]
 
 [tool.pytask.ini_options]
 paths = ["./src/bask", "./src/paper"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [metadata]
+version=0.0.1
 name = bask
 description = Scraping basketball data to predict future game outcomes
 long_description = file: README.md
@@ -35,7 +36,3 @@ zip_safe = False
 
 [options.packages.find]
 where = src
-
-[check-manifest]
-ignore =
-    src/bask/_version.py


### PR DESCRIPTION
## Problem

There seem to be two problems with your environment:

1. You try to install `os`, which is part of the standard library and is thus not found as third party package
2. `setuptools_scm` parses the version of your project wrongly. Probably related to [this issue](https://github.com/pypa/setuptools_scm/issues/630)

## Fix

- I remove `os` from the environment. Youp might want to do the same with `datetime`
- I remove `setuptools_scm` and fix the version number of your project. Since you are not writing a package, this is the more robust approach anyways. 

@NormProgr let me know if this fixes your problem